### PR TITLE
Setup Bayesian inference to avoid moralization.

### DIFF
--- a/conin/bayesian_network/inference.py
+++ b/conin/bayesian_network/inference.py
@@ -8,7 +8,7 @@ from conin.markov_network import create_MN_map_query_model
 def create_BN_map_query_model(
     *, pgm, variables=None, evidence=None, var_index_map=None, create_MN=False
 ):
-    
+
     if create_MN:
         MN = pgm.to_markov_model()
     else:


### PR DESCRIPTION
This addresses issue #54.

The default behavior is to avoid moralization, but the map_query API includes a method to specify that a Markov network is constructed using the pgmpy API.  We can use this for comparison purposes.