### PR TITLE
Lazy deletion in recursive A*

### DIFF
--- a/conin/hmm/inference/recursive_a_star.py
+++ b/conin/hmm/inference/recursive_a_star.py
@@ -193,9 +193,7 @@ def recursive_a_star(
         for h1 in hidden_states:
             temp = np.inf
             for h2 in hidden_states:
-                if (transition_probs[(h1, h2)] != 0) and (
-                    emission_probs[(h2, o)] != 0
-                ):
+                if (transition_probs[(h1, h2)] != 0) and (emission_probs[(h2, o)] != 0):
                     temp = min(
                         temp,
                         V[(t + 1, h2)]
@@ -204,9 +202,7 @@ def recursive_a_star(
                     )
             V[(t, h1)] = temp
 
-    get_gScore = (
-        dict()
-    )  # Maps recursive heap item to negative log-probabilities
+    get_gScore = dict()  # Maps recursive heap item to negative log-probabilities
     get_seq = dict()  # Maps recursive heap item ids to sequences
 
     openSet = Unique_Heapq()
@@ -219,9 +215,7 @@ def recursive_a_star(
             and ((h, observed[0]) in emission_probs.keys())
             and (emission_probs[(h, observed[0])] > 0)
         ):
-            gScore = (
-                -np.log(start_probs[h]) - log_emission_probs[(h, observed[0])]
-            )
+            gScore = -np.log(start_probs[h]) - log_emission_probs[(h, observed[0])]
             constraint_data = hmm_app.initialize_constraint_data(h)
 
             if hmm_app.constraint_data_feasible_partial(
@@ -259,9 +253,7 @@ def recursive_a_star(
 
             if t == time_steps:
                 if hmm_app.constraint_data_feasible(constraint_data):
-                    output.append(
-                        munch.Munch(hidden=list(seq), log_likelihood=-val)
-                    )
+                    output.append(munch.Munch(hidden=list(seq), log_likelihood=-val))
                     obj_vals.append(-val)
                     if len(output) == num_solutions:
                         termination_condition = "ok"
@@ -308,9 +300,7 @@ def recursive_a_star(
                 break
 
             curr_time = time.time()
-            if (max_time is not None) and (
-                (curr_time - start_time) > max_time
-            ):
+            if (max_time is not None) and ((curr_time - start_time) > max_time):
                 termination_condition = f"max_time: {curr_time - start_time}"
                 break
 

--- a/conin/hmm/tests/test_inference.py
+++ b/conin/hmm/tests/test_inference.py
@@ -31,12 +31,8 @@ def ub():
 
 @pytest.fixture
 def constraints(lb, ub):
-    num_zeros_lb = has_minimum_number_of_occurences_constraint(
-        val="h0", count=lb
-    )
-    num_zeros_ub = has_maximum_number_of_occurences_constraint(
-        val="h0", count=ub
-    )
+    num_zeros_lb = has_minimum_number_of_occurences_constraint(val="h0", count=lb)
+    num_zeros_ub = has_maximum_number_of_occurences_constraint(val="h0", count=ub)
     return [num_zeros_lb, num_zeros_ub]
 
 
@@ -317,13 +313,9 @@ class Test_Inference_a_star:
 
         inferred2 = recursive_a_star(hmm_app=recursive_app, observed=observed)
 
-        assert (
-            inferred1.termination_condition == "error: no feasible solutions"
-        )
+        assert inferred1.termination_condition == "error: no feasible solutions"
 
-        assert (
-            inferred2.termination_condition == "error: no feasible solutions"
-        )
+        assert inferred2.termination_condition == "error: no feasible solutions"
 
     def test_a_star_not_enough_solutions(self, chmm, recursive_app):
         observed = ["o1", "o1", "o1", "o1", "o1", "o1", "o1", "o1", "o1", "o1"]
@@ -454,13 +446,9 @@ class Test_Inference_ip:
 
         inferred2 = recursive_a_star(hmm_app=recursive_app, observed=observed)
 
-        assert (
-            inferred1.termination_condition == "error: no feasible solutions"
-        )
+        assert inferred1.termination_condition == "error: no feasible solutions"
 
-        assert (
-            inferred2.termination_condition == "error: no feasible solutions"
-        )
+        assert inferred2.termination_condition == "error: no feasible solutions"
 
     def Xtest_a_star_not_enough_solutions(self, chmm, recursive_app):
         observed = ["o1", "o1", "o1", "o1", "o1", "o1", "o1", "o1", "o1", "o1"]
@@ -479,9 +467,7 @@ class Test_Inference_ip:
 
         observed = ["o0", "o1", "o1", "o1"]
         hidden = (
-            ip_inference(
-                statistical_model=model, observed=observed, solver="glpk"
-            )
+            ip_inference(statistical_model=model, observed=observed, solver="glpk")
             .solutions[0]
             .hidden
         )


### PR DESCRIPTION
This should make the recursive A* algorithm significantly faster. By not doing real deletion, we go from O(n) complexity to O(log(n)) complexity. 