### PR TITLE
Pass github.head_ref through env to prevent CI script injection

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -32,6 +32,8 @@ jobs:
           black .
 
       - name: Commit and push formatting changes
+        env:
+          HEAD_REF: ${{ github.head_ref }}
         run: |
           # Check if any files have been modified
           if [ -n "$(git status --porcelain)" ]; then
@@ -39,7 +41,7 @@ jobs:
             git config --global user.email "github-actions@github.com"
             git add .
             git commit -m "Auto apply black [skip ci]"
-            git push origin ${{ github.head_ref }}  # Push changes to the same PR branch
+            git push origin "$HEAD_REF"  # Push changes to the same PR branch
           else
             echo "No formatting changes detected."
           fi


### PR DESCRIPTION
Small CI hardening for `.github/workflows/pytest.yml`.

The step that pushes Black's auto-formatting back to the PR branch uses an inline expression:

```yaml
git push origin ${{ github.head_ref }}
```

The trouble is that `github.head_ref` carries the source branch name of the pull request, and the person opening the PR decides what that is. Workflow expressions are evaluated and pasted into the script text before the shell ever sees it, so a branch name containing shell syntax becomes part of the command and can execute on the runner. This is the script-injection scenario covered in GitHub's hardening guide: https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#understanding-the-risk-of-script-injections

Fix is to hand the value to the step as an environment variable and use that variable, quoted, in the command:

```yaml
env:
  HEAD_REF: ${{ github.head_ref }}
run: |
  ...
  git push origin "$HEAD_REF"
```

Environment variables are not re-parsed by the shell, so the branch name stays data. No functional change. I deliberately left the `ref: ${{ github.head_ref }}` on the checkout step untouched since that is a normal action input and not a shell context. zizmor and CodeQL (`actions/expression-injection`) both flag the original `run:` usage.