### PR TITLE
206 mvr operators pass on metadata

### DIFF
--- a/conin/hidden_markov_model/mvr.py
+++ b/conin/hidden_markov_model/mvr.py
@@ -47,9 +47,9 @@ class BaseMVR:
     evl: Any
 
     _repn: MVR_MatVecRepn  # numerical representation like HMM_MatVecRepn
-    _prefix: bool  # prefix-free tag.
+    _prefix: bool  # certifies if prefix-free
     _time_range: list[int] | None
-    _name: str | None  # optional label for this instance.
+    _name: str | None  # optional label for this instance
 
     def __init__(self):
         """Initialize the base MVR state."""

--- a/conin/hidden_markov_model/mvr.py
+++ b/conin/hidden_markov_model/mvr.py
@@ -7,6 +7,32 @@ from typing import Any
 from itertools import product
 
 
+def _normalize_time_range(
+    time_range: list[int] | None,
+    time_horizon: int | None = None,
+) -> list[int] | None:
+    """Validate a time range and return a copy the MVR owns, or None."""
+    if time_range is None:
+        return None
+
+    if not (
+        isinstance(time_range, list)
+        and len(time_range) == 2
+        and all(type(time) is int and time >= 0 for time in time_range)
+        and time_range[0] <= time_range[1]
+    ):
+        raise InvalidInputError(
+            "time range must be a list of two nonnegative integers, with start <= end"
+        )
+
+    if time_horizon is not None and time_range[1] - time_range[0] > time_horizon:
+        raise InvalidInputError(
+            "time range cannot be longer than the time horizon of an Inhom MVR"
+        )
+
+    return list(time_range)
+
+
 class BaseMVR:
     """Base class for mediation variable representations (MVRs).
 
@@ -54,6 +80,14 @@ class BaseMVR:
             Prefix-free tag for the representation.
         """
         return self._prefix
+
+    @property
+    def time_range(self):
+        """Return the ``[start, end]`` range attached to the MVR, or None.
+
+        Read-only; set it with the ``mvr_timerange`` operator.
+        """
+        return self._time_range
 
     @property
     def repn(self):
@@ -154,18 +188,7 @@ class HomMVR(BaseMVR):
         self.ini = dict(ini)
         self.upd = dict(upd)
         self.evl = dict(evl)
-
-        if time_range is not None:
-            if not (
-                isinstance(time_range, list)
-                and len(time_range) == 2
-                and all(type(time) is int and time >= 0 for time in time_range)
-                and time_range[0] <= time_range[1]
-            ):
-                raise InvalidInputError(
-                    "time range must be a list of two nonnegative integers, with start <= end"
-                )
-            self._time_range = time_range
+        self._time_range = _normalize_time_range(time_range)
 
         self.name = name
         # Build repn
@@ -314,23 +337,7 @@ class InhomMVR(BaseMVR):
         self.upd = [dict(upd_t) for upd_t in upd]
         self.evl = [dict(evl_t) for evl_t in evl]
         self.time_horizon = time_horizon
-
-        if time_range is not None:
-            if not (
-                isinstance(time_range, list)
-                and len(time_range) == 2
-                and all(type(time) is int and time >= 0 for time in time_range)
-                and time_range[0] <= time_range[1]
-            ):
-                raise InvalidInputError(
-                    "time range must be a list of two nonnegative integers, with start <= end"
-                )
-            time_diff = time_range[1] - time_range[0]
-            if time_diff > time_horizon:
-                raise InvalidInputError(
-                    "time range cannot be longer than the time horizon of an Inhom MVR"
-                )
-            self._time_range = time_range
+        self._time_range = _normalize_time_range(time_range, time_horizon)
 
         self.name = name
         # Build repn

--- a/conin/hidden_markov_model/mvr_operators.py
+++ b/conin/hidden_markov_model/mvr_operators.py
@@ -45,6 +45,7 @@ def _combined_time_horizon(mvrs: list[MVR]) -> int | None:
 # If operating on a subsequence constraint (MVR with time_range),
 # please call this at the end to regenerate time_range.
 
+
 @mvr_operator_fn(arity=1)
 def mvr_timerange(
     mvrs: list[MVR],

--- a/conin/hidden_markov_model/mvr_operators.py
+++ b/conin/hidden_markov_model/mvr_operators.py
@@ -8,7 +8,7 @@ from typing import Any, Literal
 from conin.exceptions import InvalidInputError
 
 # Adjust this import path as needed.
-from conin.hidden_markov_model.mvr import HomMVR, InhomMVR
+from conin.hidden_markov_model.mvr import HomMVR, InhomMVR, _normalize_time_range
 from conin.operators import mvr_operator_fn
 
 MVR = HomMVR | InhomMVR
@@ -34,6 +34,64 @@ def _combined_time_horizon(mvrs: list[MVR]) -> int | None:
         )
 
     return min_horizon
+
+
+# ------------------------------------------------------------------
+# Set TimeRange
+# ------------------------------------------------------------------
+
+# IMPORTANT: Every operator other than mvr_timerange drops "_time_range" silently.
+# Outside of initialization, mvr_timerange is the sole setter of "_time_range".
+# If operating on a subsequence constraint (MVR with time_range),
+# please call this at the end to regenerate time_range.
+
+@mvr_operator_fn(arity=1)
+def mvr_timerange(
+    mvrs: list[MVR],
+    time_range: list[int] = None,
+    inplace: bool = True,
+) -> MVR:
+    """
+    Sets the time range of an MVR for subsequence constraints.
+    Defaults to inplace=True, directly changing the MVR.
+
+    Also passes along the "prefix" tag.
+    """
+    mvr = mvrs[0]
+
+    if not isinstance(mvr, (HomMVR, InhomMVR)):
+        raise InvalidInputError("mvr must be an instance of HomMVR or InhomMVR.")
+
+    if inplace:
+        time_horizon = mvr.time_horizon if isinstance(mvr, InhomMVR) else None
+        mvr._time_range = _normalize_time_range(time_range, time_horizon)
+        return mvr
+
+    if isinstance(mvr, HomMVR):
+        result = HomMVR(
+            hidden_states=list(mvr.hidden_states),
+            mediation_states=list(mvr.mediation_states),
+            ini=dict(mvr.ini),
+            upd=dict(mvr.upd),
+            evl=dict(mvr.evl),
+            time_range=time_range,
+            name=mvr.name,
+        )
+    else:
+        result = InhomMVR(
+            hidden_states=list(mvr.hidden_states),
+            mediation_states=[
+                list(mediation_states_t) for mediation_states_t in mvr.mediation_states
+            ],
+            ini=dict(mvr.ini),
+            upd=[dict(upd_t) for upd_t in mvr.upd],
+            evl=[dict(evl_t) for evl_t in mvr.evl],
+            time_range=time_range,
+            name=mvr.name,
+        )
+
+    result._prefix = mvr._prefix
+    return result
 
 
 # ------------------------------------------------------------------

--- a/conin/hidden_markov_model/mvr_operators.py
+++ b/conin/hidden_markov_model/mvr_operators.py
@@ -234,10 +234,14 @@ def mvr_and(
         "Use the AND operator sparingly. It's generally more efficient to provide a list of MVRs to downstream algorithms.",
         UserWarning,
     )
-    return _boolean_combine_mvrs(
+    result = _boolean_combine_mvrs(
         mvrs,
         all,
     )
+
+    # Respects prefix property: output has _prefix=True if any input does.
+    result._prefix = any(mvr.prefix for mvr in mvrs)
+    return result
 
 
 @mvr_operator_fn(arity=None)
@@ -442,8 +446,8 @@ def mvr_sattime(
     if not isinstance(mvr, (HomMVR, InhomMVR)):
         raise InvalidInputError("mvr_sattime expects a HomMVR or InhomMVR.")
 
-    if mvr.prefix:  # if already prefix-free, then do nothing.
-        print("MVR is already prefix-free. Returning original MVR")
+    # sattime(L) == L when L is prefix-free, so the input is already the answer.
+    if mvr.prefix:
         return mvr
 
     # Create a fresh absorbing fail state.
@@ -617,13 +621,17 @@ def mvr_setdiff(
         for m2 in mvr2.mediation_states
     }
 
-    return HomMVR(
+    result = HomMVR(
         hidden_states=hidden_states,
         mediation_states=mediation_states,
         ini=ini,
         upd=upd,
         evl=evl,
     )
+
+    # Respects prefix property: output has _prefix=True if mvr1 does.
+    result._prefix = mvr1.prefix
+    return result
 
 
 @mvr_operator_fn(arity=2)
@@ -698,13 +706,17 @@ def mvr_concatenate(
         for active_m2_states in mvr2_subsets
     }
 
-    return HomMVR(
+    result = HomMVR(
         hidden_states=hidden_states,
         mediation_states=mediation_states,
         ini=ini,
         upd=upd,
         evl=evl,
     )
+
+    # Respects prefix property: output has _prefix=True if both inputs do.
+    result._prefix = mvr1.prefix and mvr2.prefix
+    return result
 
 
 @mvr_operator_fn(arity=2)
@@ -801,13 +813,17 @@ def mvr_kfold_product(
         raise InvalidInputError("k must be an integer greater than or equal to 1.")
 
     if k == 1:
-        return HomMVR(
+        result = HomMVR(
             hidden_states=list(mvr.hidden_states),
             mediation_states=list(mvr.mediation_states),
             ini=dict(mvr.ini),
             upd=dict(mvr.upd),
             evl=dict(mvr.evl),
         )
+
+        # Respects prefix property: output has _prefix=True if input does.
+        result._prefix = mvr.prefix
+        return result
 
     return mvr_concatenate(
         [

--- a/conin/hidden_markov_model/tests/test_mvr_chmm.py
+++ b/conin/hidden_markov_model/tests/test_mvr_chmm.py
@@ -661,7 +661,7 @@ def test_mvr_accepts_valid_time_range_list(mvr_type, time_range):
     )
 
     assert mvr._time_range == time_range
-    assert mvr._time_range is time_range
+    assert mvr._time_range is not time_range  # the MVR owns its range
 
 
 @pytest.mark.parametrize("mvr_type", ["hom", "inhom"])

--- a/conin/hidden_markov_model/tests/test_mvr_operators.py
+++ b/conin/hidden_markov_model/tests/test_mvr_operators.py
@@ -1,9 +1,10 @@
 import pytest
 
 from conin.exceptions import InvalidInputError
-from conin.hidden_markov_model.mvr import HomMVR
+from conin.hidden_markov_model.mvr import HomMVR, InhomMVR
 
 from conin.hidden_markov_model.mvr_operators import (
+    mvr_timerange,
     mvr_and,
     mvr_or,
     mvr_not,
@@ -169,6 +170,19 @@ def exact_word_mvr(word):
         ini=ini,
         upd=upd,
         evl=evl,
+    )
+
+
+def trivial_inhom_mvr(time_horizon):
+    """
+    Language: every word within the horizon. Carries a horizon, unlike the rest.
+    """
+    return InhomMVR(
+        hidden_states=list(ALPHABET),
+        mediation_states=[[0]] * (time_horizon + 1),
+        ini={h: 0 for h in ALPHABET},
+        upd=[{(0, h): 0 for h in ALPHABET} for _ in range(time_horizon)],
+        evl=[{0: True}] * (time_horizon + 1),
     )
 
 
@@ -606,3 +620,40 @@ def test_mvr_count():
 
     with pytest.raises(InvalidInputError):
         mvr_count(single_a, "not a valid condition")
+
+
+def test_mvr_timerange():
+    contains_a = contains_symbol_mvr("a")
+
+    time_range = [1, 3]
+    result = mvr_timerange(contains_a, time_range)
+
+    assert result is contains_a  # inplace=True mutates and returns the input
+    assert result.time_range == [1, 3]
+    assert result.time_range is not time_range  # the MVR owns its range
+
+    assert mvr_timerange(contains_a).time_range is None  # a bare call clears it
+
+    # The horizon check applies on the inplace path, which skips the constructor.
+    inhom = trivial_inhom_mvr(time_horizon=3)
+
+    assert mvr_timerange(inhom, [5, 7]).time_range == [5, 7]
+
+    with pytest.raises(InvalidInputError):
+        mvr_timerange(inhom, [0, 4])
+
+    # inplace=False rebuilds instead, leaving the input alone.
+    single_a = exact_word_mvr("a")
+    single_a.name = "single_a"
+    single_a._prefix = True
+
+    rebuilt = mvr_timerange(single_a, [1, 3], inplace=False)
+
+    assert rebuilt is not single_a
+    assert single_a.time_range is None
+
+    assert rebuilt.time_range == [1, 3]
+    assert rebuilt.name == "single_a"
+    assert rebuilt._prefix is True
+
+    assert_language(rebuilt, {"a": True, "b": False, "aa": False, "ab": False})

--- a/conin/hidden_markov_model/tests/test_mvr_operators.py
+++ b/conin/hidden_markov_model/tests/test_mvr_operators.py
@@ -690,7 +690,11 @@ PREFIX_PROPAGATION = {
     "setdiff_first": (lambda cert, plain: mvr_setdiff([cert, plain]), True, True),
     "setdiff_second": (lambda cert, plain: mvr_setdiff([plain, cert]), False, False),
     "concatenate_both": (lambda cert, plain: mvr_concatenate([cert, cert]), True, True),
-    "concatenate_half": (lambda cert, plain: mvr_concatenate([cert, plain]), False, False),
+    "concatenate_half": (
+        lambda cert, plain: mvr_concatenate([cert, plain]),
+        False,
+        False,
+    ),
     "kfold_1": (lambda cert, plain: mvr_kfold_product(cert, 1), True, True),
     "kfold_3": (lambda cert, plain: mvr_kfold_product(cert, 3), True, True),
     "or": (

--- a/conin/hidden_markov_model/tests/test_mvr_operators.py
+++ b/conin/hidden_markov_model/tests/test_mvr_operators.py
@@ -1,5 +1,7 @@
 import pytest
 
+from itertools import product
+
 from conin.exceptions import InvalidInputError
 from conin.hidden_markov_model.mvr import HomMVR, InhomMVR
 
@@ -67,6 +69,22 @@ def assert_language(mvr, expected):
     """
     for word, value in expected.items():
         assert eval_mvr(mvr, list(word)) is value, f"word={word!r}"
+
+
+def is_prefix_free(mvr, max_len=5):
+    """
+    Brute force: no accepted word up to max_len properly prefixes another.
+    """
+    accepted = [
+        word
+        for length in range(1, max_len + 1)
+        for word in product(ALPHABET, repeat=length)
+        if eval_mvr(mvr, list(word))
+    ]
+
+    return not any(
+        len(u) < len(v) and v[: len(u)] == u for u in accepted for v in accepted
+    )
 
 
 def contains_symbol_mvr(symbol):
@@ -333,6 +351,8 @@ def test_mvr_sattime():
             "aba": False,
         },
     )
+
+    assert mvr_sattime(result) is result  # sattime(L) == L when L is prefix-free
 
     with pytest.raises(InvalidInputError):
         mvr_sattime([contains_a, single_b])
@@ -657,3 +677,47 @@ def test_mvr_timerange():
     assert rebuilt._prefix is True
 
     assert_language(rebuilt, {"a": True, "b": False, "aa": False, "ab": False})
+
+
+# ---------------------------------------------------------------------
+# The prefix-free certificate
+# ---------------------------------------------------------------------
+
+# A declared True must never outrun the truth; a declared False may be conservative.
+PREFIX_PROPAGATION = {
+    "and_certified": (lambda cert, plain: mvr_and([cert, plain]), True, True),
+    "and_uncertified": (lambda cert, plain: mvr_and([plain, plain]), False, False),
+    "setdiff_first": (lambda cert, plain: mvr_setdiff([cert, plain]), True, True),
+    "setdiff_second": (lambda cert, plain: mvr_setdiff([plain, cert]), False, False),
+    "concatenate_both": (lambda cert, plain: mvr_concatenate([cert, cert]), True, True),
+    "concatenate_half": (lambda cert, plain: mvr_concatenate([cert, plain]), False, False),
+    "kfold_1": (lambda cert, plain: mvr_kfold_product(cert, 1), True, True),
+    "kfold_3": (lambda cert, plain: mvr_kfold_product(cert, 3), True, True),
+    "or": (
+        lambda cert, plain: mvr_or([cert, mvr_kfold_product(cert, 2)]),
+        False,
+        False,
+    ),
+    "kleene_closure_prefix": (
+        lambda cert, plain: mvr_kleene_closure_prefix(cert),
+        False,
+        False,
+    ),
+}
+
+
+@pytest.mark.filterwarnings("ignore")
+@pytest.mark.parametrize("case", PREFIX_PROPAGATION)
+def test_prefix_propagation(case):
+    build, declared, truly_prefix_free = PREFIX_PROPAGATION[case]
+
+    cert = mvr_sattime(contains_symbol_mvr("a"))  # b*a, prefix-free
+    plain = contains_symbol_mvr("b")
+
+    result = build(cert, plain)
+
+    assert result.prefix is declared
+    assert is_prefix_free(result) is truly_prefix_free
+
+    # Deliberately redundant: the one check no edit to the table can defeat.
+    assert not result.prefix or is_prefix_free(result)


### PR DESCRIPTION
-time_range: silently dropped by operators, with mvr_timerange as sole setter outside of initialization
-prefix: only operators that provably respect prefix-free property pass it on.
-name: remain as a label to be set manually